### PR TITLE
アイテム価格の決定に専用クラスを使用するように変更したい

### DIFF
--- a/src/main/java/shift/mceconomy2/api/MCEconomyAPI.java
+++ b/src/main/java/shift/mceconomy2/api/MCEconomyAPI.java
@@ -21,6 +21,7 @@ import net.minecraft.world.World;
 import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.fluids.FluidRegistry;
 import net.minecraftforge.oredict.OreDictionary;
+import shift.mceconomy2.api.purchase.IPurchaseItem;
 import shift.mceconomy2.api.shop.IProductList;
 import shift.mceconomy2.api.shop.IShopManager;
 import shift.mceconomy2.api.shop.ProductList;
@@ -152,14 +153,31 @@ public class MCEconomyAPI {
 		ShopManager.openShopGui(id, player, world, x, y, z);
 	}
 
+    /**
+     * addPurchaseItem Mobなどがアイテムを買い取る価格を判定するクラスを登録
+     * @param purchaseItem 登録するIPurchaseItemクラス
+     */
+    public static void addPurchaseItem(IPurchaseItem purchaseItem) {
+        ShopManager.addPurchaseItem(purchaseItem);
+    }
+
 	/**
-	 * addPurchaseItem Mobなどがアイテムを買い取る価格を登録
+	 * addPurchaseItem Mobなどがアイテムを買い取る価格をItemStackで登録
 	 * @param PurchaseItem 買い取りアイテム
 	 * @param amount 価格  -1で非売品に設定出来ます
 	 */
 	public static void addPurchaseItem(ItemStack PurchaseItem, int amount) {
 		ShopManager.addPurchaseItem(PurchaseItem, amount);
 	}
+
+    /**
+     * addPurchaseItem Mobなどがアイテムを買い取る価格を鉱石辞書名で登録
+     * @param oreName 買い取り対象となる鉱石辞書名
+     * @param amount 価格  -1で非売品に設定出来ます
+     */
+    public static void addPurchaseItem(String oreName, int amount) {
+        ShopManager.addPurchaseItem(oreName, amount);
+    }
 
 	/**
 	 * getPurchase アイテムの買い取り額を取得
@@ -181,8 +199,8 @@ public class MCEconomyAPI {
 
 	/**
 	 * addPurchaseItem Mobなどが流体を買い取る価格を登録
-	 * @param PurchaseItem 買い取る流体
-	 * @param amount 価格(1mB)  -1で非売品に設定出来ます
+	 * @param fluid 買い取る流体
+	 * @param mp 価格(1mB)  -1で非売品に設定出来ます
 	 */
 	public static void addPurchaseFluid(Fluid fluid, double mp) {
 		ShopManager.addPurchaseFluid(fluid, mp);
@@ -190,7 +208,7 @@ public class MCEconomyAPI {
 
 	/**
 	 * getPurchase 流体の買い取り額を取得
-	 * @param item 売る流体
+	 * @param fluid 売る流体
 	 * @return 価格(1mB)
 	 */
 	public static double getFluidPurchase(Fluid fluid) {
@@ -199,7 +217,7 @@ public class MCEconomyAPI {
 
 	/**
 	 * hasPurchase 流体に価格が設定されているか
-	 * @param item 調べる流体
+	 * @param fluid 調べる流体
 	 * @return 設定されていればtrue 非売品はfalseになります.
 	 */
 	public static boolean hasFluidPurchase(Fluid fluid) {

--- a/src/main/java/shift/mceconomy2/api/purchase/IPurchaseItem.java
+++ b/src/main/java/shift/mceconomy2/api/purchase/IPurchaseItem.java
@@ -1,0 +1,24 @@
+package shift.mceconomy2.api.purchase;
+
+import net.minecraft.item.ItemStack;
+
+/**
+ * Created by plusplus_F on 2016/03/29.
+ * アイテムの値段設定を処理するクラス <br>
+ * このクラスによって基本の価格が決定された後にPriceEventが発生する
+ */
+public interface IPurchaseItem {
+    /**
+     * 引数のItemStackがこのインスタンスで扱っているかを返す
+     * @param itemStack
+     * @return trueの場合、このクラスで処理できる
+     */
+    public boolean isMatch(ItemStack itemStack);
+
+    /**
+     * 引数のItemStackの売却価格を返す
+     * @param itemStack
+     * @return 売却価格
+     */
+    public int getPrice(ItemStack itemStack);
+}

--- a/src/main/java/shift/mceconomy2/api/purchase/PurchaseItemStack.java
+++ b/src/main/java/shift/mceconomy2/api/purchase/PurchaseItemStack.java
@@ -1,0 +1,34 @@
+package shift.mceconomy2.api.purchase;
+
+import net.minecraft.item.ItemStack;
+
+/**
+ * Created by plusplus_F on 2016/03/29.
+ * 前のバージョンとの互換性を保つためのクラス
+ */
+public class PurchaseItemStack implements IPurchaseItem {
+    /**
+     * このクラスが保持するアイテム
+     */
+    protected ItemStack itemStack;
+
+    /**
+     * 売却価格
+     */
+    protected int price;
+
+    public PurchaseItemStack(ItemStack itemStack, int price){
+        this.itemStack=itemStack;
+        this.price=price;
+    }
+
+    @Override
+    public boolean isMatch(ItemStack itemStack) {
+        return this.itemStack.getItem() == itemStack.getItem() && (this.itemStack.getItemDamage() == 32767 || this.itemStack.getItemDamage() == itemStack.getItemDamage());
+    }
+
+    @Override
+    public int getPrice(ItemStack itemStack) {
+        return price;
+    }
+}

--- a/src/main/java/shift/mceconomy2/api/purchase/PurchaseOreDictionary.java
+++ b/src/main/java/shift/mceconomy2/api/purchase/PurchaseOreDictionary.java
@@ -1,0 +1,38 @@
+package shift.mceconomy2.api.purchase;
+
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.oredict.OreDictionary;
+
+/**
+ * Created by plusplus_F on 2016/03/29.
+ */
+public class PurchaseOreDictionary implements IPurchaseItem {
+    /**
+     * このクラスが扱う鉱石辞書ID
+     */
+    protected int oreId;
+
+    /**
+     * 売却価格
+     */
+    protected int price;
+
+    public PurchaseOreDictionary(String oreName, int price){
+        oreId= OreDictionary.getOreID(oreName);
+        this.price=price;
+    }
+
+    @Override
+    public boolean isMatch(ItemStack itemStack) {
+        int[] ids=OreDictionary.getOreIDs(itemStack);
+        for(int i : ids){
+            if(oreId==i) return true;
+        }
+        return false;
+    }
+
+    @Override
+    public int getPrice(ItemStack itemStack) {
+        return price;
+    }
+}

--- a/src/main/java/shift/mceconomy2/api/shop/IShopManager.java
+++ b/src/main/java/shift/mceconomy2/api/shop/IShopManager.java
@@ -7,6 +7,7 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.world.World;
 import net.minecraftforge.fluids.Fluid;
+import shift.mceconomy2.api.purchase.IPurchaseItem;
 
 
 /**
@@ -23,7 +24,11 @@ public interface IShopManager {
 
 	public void openShopGui(int id, EntityPlayer player, World world, int x, int y, int z);
 
-	public void addPurchaseItem(ItemStack par1ItemStack, Integer par2Integer);
+	public void addPurchaseItem(IPurchaseItem purchaseItem);
+
+    public void addPurchaseItem(ItemStack par1ItemStack, Integer par2Integer);
+
+    public void addPurchaseItem(String par1String, Integer par2Integer);
 
 	public int getPurchase(ItemStack item);
 


### PR DESCRIPTION
## 概要

アイテムの売却価格の決定に、IPurchaseItemクラスを用いるようにした。
この変更により、MCE2単体ではItemStackだけでなく、鉱石辞書名でも売却価格が設定できるようになった。
さらに、他のmodからはIPurchaseItemクラスを実装することで、PriceEventに頼らずに売却可否の判定、売却価格の取得ができるようになった。
IPurchaseItemクラスによる価格の取得の直後に、PriceEventが呼ばれるため、鉱石辞書など広範囲に渡る価格設定が気に入らない場合はPriceEventで直接価格が書き換えられるはず。
## 主な影響範囲

ShopManagerやIShopManagerにメソッドが増えた。
apiパッケージ内に新しくpurchaseパッケージができた。
以前のバージョンとの互換性は保たれているはず。
あとPriceEventもきっとちゃんと動作するはず。
## 備考

開発環境の関係で括弧の位置とかインデントが変かもしれないけどゆるして
